### PR TITLE
Prep for v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-### 0.4.2 (Next)
+### 0.5.1 (Next)
+
+* Your contribution here.
+
+### 0.5.0
 
 * [#10](https://github.com/mongoid/mongoid-compatibility/pull/10): Compatibility with Mongoid 7.x - [@joeyAghion](https://github.com/joeyAghion).
-* Your contribution here.
 
 ### 0.4.1 (2017/01/19)
 

--- a/lib/mongoid/compatibility/self.rb
+++ b/lib/mongoid/compatibility/self.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module Compatibility
-    VERSION = '0.4.2'.freeze
+    VERSION = '0.5.0'.freeze
   end
 end


### PR DESCRIPTION
Given the [backwards-compatible] API change, I think a minor version number bump is appropriate.

Would appreciate a release once this is merged.