### PR TITLE
Add gem caching to test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,13 @@ jobs:
           - { ruby: "3.1", gemfile: 'mongoid_8', mongodb: "7.0" }
           - { ruby: "3.1", gemfile: 'mongoid_9', mongodb: "7.0" }
     steps:
+      - name: Cache Gems
+        uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gem-
       - name: Set up MongoDB ${{ matrix.entry.mongodb }}
         uses: supercharge/mongodb-github-action@1.8.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 1.1.0 (Next)
 * Your contribution here.
+* [#20](https://github.com/mongoid/mongoid-compatibility/pull/20): Add gem caching to CI - [@saisrinivasan](https://github.com/SairamSrinivasan).
 
 ### 1.0.0 (2024/06/19)
 


### PR DESCRIPTION
This PR introduces a step in the CI test pipeline that stores the installed dependencies. The cache key includes a hash of the lock file.